### PR TITLE
TSM-290 : psh-toolbelt Related Deprecated Code Fixes

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -12,13 +12,7 @@ parameters:
       message: '#Undefined variable: \$site_path#'
       path: %currentWorkingDirectory%/src/site.settings.php
     -
-      message: '#Constant CONFIG_SYNC_DIRECTORY not found.#'
-      path: %currentWorkingDirectory%/src/site.settings.php
-    -
       message: '#Constant DRUPAL_ROOT not found.#'
-      path: %currentWorkingDirectory%/src/SiteSettings.php
-    -
-      message: '#Constant CONFIG_SYNC_DIRECTORY not found.#'
       path: %currentWorkingDirectory%/src/SiteSettings.php
     -
       message: '#Call to an undefined method [a-zA-Z0-9\\_]+::replace\(\).#'

--- a/src/SiteSettings.php
+++ b/src/SiteSettings.php
@@ -95,7 +95,8 @@ class SiteSettings {
   public function setDefaults() : void {
     $this->settings['trusted_host_patterns']        = [];
     $this->settings['update_free_access']           = FALSE;
-    $this->configDirectories[CONFIG_SYNC_DIRECTORY] = implode(
+    $this->settings['config_sync_directory'] = implode(
+    //$this->configDirectories[CONFIG_SYNC_DIRECTORY] = implode(
       '/',
       [
         '..',

--- a/src/SiteSettings.php
+++ b/src/SiteSettings.php
@@ -95,8 +95,7 @@ class SiteSettings {
   public function setDefaults() : void {
     $this->settings['trusted_host_patterns']        = [];
     $this->settings['update_free_access']           = FALSE;
-    $this->settings['config_sync_directory'] = implode(
-    //$this->configDirectories[CONFIG_SYNC_DIRECTORY] = implode(
+    $this->settings['config_sync_directory']        = implode(
       '/',
       [
         '..',

--- a/src/site.settings.php
+++ b/src/site.settings.php
@@ -40,9 +40,7 @@ if (PHP_SAPI === 'cli') {
     foreach ($args as $arg) {
       if ($arg === 'config:export' || $arg === 'cex' || $arg === 'config-export') {
         $configSplit = $configFileReader->getConfigSplitFromRoboConfig();
-
-        //$config_directories[CONFIG_SYNC_DIRECTORY]              = $configSplit['default']['folder'];
-        $settings['config_sync_directory']                      = $configSplit['default']['folder'];
+        $settings['config_sync_directory'] = $configSplit['default']['folder'];
         $config[$configSplit['prod']['machine_name']]['folder'] = $configSplit['prod']['folder'];
 
         break;

--- a/src/site.settings.php
+++ b/src/site.settings.php
@@ -41,7 +41,8 @@ if (PHP_SAPI === 'cli') {
       if ($arg === 'config:export' || $arg === 'cex' || $arg === 'config-export') {
         $configSplit = $configFileReader->getConfigSplitFromRoboConfig();
 
-        $config_directories[CONFIG_SYNC_DIRECTORY]              = $configSplit['default']['folder'];
+        //$config_directories[CONFIG_SYNC_DIRECTORY]              = $configSplit['default']['folder'];
+        $settings['config_sync_directory']                      = $configSplit['default']['folder'];
         $config[$configSplit['prod']['machine_name']]['folder'] = $configSplit['prod']['folder'];
 
         break;


### PR DESCRIPTION
Jira : https://wearewondrous.atlassian.net/browse/TSM-290

**Drupal Core < 9.0.0**
   PR  : https://github.com/wearewondrous/babygalerie-backend/pull/6
   psh : https://pr-6-3qodc7y-bfxbqq655tzes.eu.platform.sh/ 
**Drupal Core >= 9.0.0**
   PR  : https://github.com/wearewondrous/babygalerie-backend/pull/5
   psh : https://pr-5-kehpj4q-bfxbqq655tzes.eu.platform.sh/


### **DESCRIPTION**
In Drupal 9 `CONFIG_SYNC_DIRECTORY `constant is removed from the system. The config sync directory is where Drupal stores your exported configuration YAML files. Before Drupal 8.8, you could configure multiple directories for exporting config; now there's only one, and the variable name has changed to $settings['config_sync_directory'].
For More Details : 

- https://www.palantir.net/blog/guide-drupal-8-8-update
- https://www.drupal.org/node/3018145

We were getting this following error during D9 upgrade on Hudson.
```
vagrant@hudsongroup:/var/www/drupalvm/web$ ../vendor/bin/drush updb

In FileStorageFactory.php line 26:
                                                                                  
  The config sync directory is not defined in $settings["config_sync_directory"]
```

Though we can't test psh-toolbelt directly, We took [Babygalerie](https://github.com/wearewondrous/babygalerie-backend) as our test environment. We fix deprecated/removed code from psh-toolbelt on a branch. And install psh-toolbelt via composer command :
`composer require wearewondrous/psh-toolbelt dev-TSM-290-Config-Sync-Directory-Fix#46b21f0debd5618f786b8b371dfe3c91e6ffeab6`

We are sourcing from this commit hash `46b21f0debd5618f786b8b371dfe3c91e6ffeab6` which contains the necessary fixes !

### **GOAL** 

- Fix the deprecation in psh-toolbelt.

### **ACCEPTANCE**

- The error is resolved 
- Works properly on local development as well as hosting
