### PR TITLE
TSM-407 File Backup Issue Fix

### DIFF
--- a/src/Commands/BackupCommands.php
+++ b/src/Commands/BackupCommands.php
@@ -314,11 +314,15 @@ class BackupCommands extends BaseCommands {
       $fileDeleted = unlink($pathToFile);
       
       if($fileDeleted !== FALSE) {
+        var_dump($pathToFile);
+        var_dump("Path To File File Deleted");
         $this->sentryClient->captureMessage("Successfully purged db backup temp file: " . $pathToFile, [], [
           'level' => 'info',
         ]);
       }
       else {
+        var_dump($pathToFile);
+        var_dump("Path To File File not Deleted");
         $this->sentryClient->captureMessage("Could not purge db backup temp file: " . $pathToFile, [], [
           'level' => 'error',
         ]);
@@ -397,11 +401,15 @@ class BackupCommands extends BaseCommands {
       $fileDeleted = unlink($targetFile);
       
       if($fileDeleted !== FALSE) {
+        var_dump($targetFile);
+        var_dump(" File Deleted");
         $this->sentryClient->captureMessage("Successfully purged archieved temp file: " . $targetFile, [], [
           'level' => 'info',
         ]);
       }
       else {
+        var_dump($targetFile);
+        var_dump(" File not Deleted");
         $this->sentryClient->captureMessage("Could not purge archieved temp file: " . $targetFile, [], [
           'level' => 'error',
         ]);

--- a/src/Commands/BackupCommands.php
+++ b/src/Commands/BackupCommands.php
@@ -297,7 +297,6 @@ class BackupCommands extends BaseCommands {
       ]);
       $this->multipartUploader->upload();
 
-      unlink($pathToFile);
       $this->sentryClient->captureMessage(
             'DB backed up in: ' . $objectKey,
             [],
@@ -310,6 +309,20 @@ class BackupCommands extends BaseCommands {
             [],
             ['level' => 'error']
             );
+    }
+    finally {
+      $fileDeleted = unlink($pathToFile);
+      
+      if($fileDeleted !== FALSE) {
+        $this->sentryClient->captureMessage("Successfully purged db backup temp file: " . $pathToFile, [], [
+          'level' => 'info',
+        ]);
+      }
+      else {
+        $this->sentryClient->captureMessage("Could not purge db backup temp file: " . $pathToFile, [], [
+          'level' => 'error',
+        ]);
+      }
     }
   }
 
@@ -366,7 +379,6 @@ class BackupCommands extends BaseCommands {
         ]);
         $this->multipartUploader->upload();
 
-        unlink($targetFile);
         $this->sentryClient->captureMessage(
               sprintf('%s-files backed up in: ', $key) . $objectKey,
               [],
@@ -380,6 +392,20 @@ class BackupCommands extends BaseCommands {
             [],
             ['level' => 'error']
             );
+    }
+    finally {
+      $fileDeleted = unlink($targetFile);
+      
+      if($fileDeleted !== FALSE) {
+        $this->sentryClient->captureMessage("Successfully purged archieved temp file: " . $targetFile, [], [
+          'level' => 'info',
+        ]);
+      }
+      else {
+        $this->sentryClient->captureMessage("Could not purge archieved temp file: " . $targetFile, [], [
+          'level' => 'error',
+        ]);
+      }
     }
   }
 

--- a/src/Commands/BackupCommands.php
+++ b/src/Commands/BackupCommands.php
@@ -314,16 +314,12 @@ class BackupCommands extends BaseCommands {
       $fileDeleted = unlink($pathToFile);
       
       if($fileDeleted !== FALSE) {
-        var_dump($pathToFile);
-        var_dump("Path To File File Deleted");
-        $this->sentryClient->captureMessage("Successfully purged db backup temp file: " . $pathToFile, [], [
+        $this->sentryClient->captureMessage("Successfully purged temp file: " . $pathToFile, [], [
           'level' => 'info',
         ]);
       }
       else {
-        var_dump($pathToFile);
-        var_dump("Path To File File not Deleted");
-        $this->sentryClient->captureMessage("Could not purge db backup temp file: " . $pathToFile, [], [
+        $this->sentryClient->captureMessage("Could not purge temp file: " . $pathToFile, [], [
           'level' => 'error',
         ]);
       }
@@ -400,16 +396,12 @@ class BackupCommands extends BaseCommands {
         $fileDeleted = unlink($targetFile);
         
         if($fileDeleted !== FALSE) {
-          var_dump($targetFile);
-          var_dump(" File Deleted");
-          $this->sentryClient->captureMessage("Successfully purged archieved temp file: " . $targetFile, [], [
+          $this->sentryClient->captureMessage("Successfully purged temp file: " . $targetFile, [], [
             'level' => 'info',
           ]);
         }
         else {
-          var_dump($targetFile);
-          var_dump(" File not Deleted");
-          $this->sentryClient->captureMessage("Could not purge archieved temp file: " . $targetFile, [], [
+          $this->sentryClient->captureMessage("Could not purge temp file: " . $targetFile, [], [
             'level' => 'error',
           ]);
         }

--- a/src/Commands/BackupCommands.php
+++ b/src/Commands/BackupCommands.php
@@ -348,8 +348,8 @@ class BackupCommands extends BaseCommands {
           ]
       );
 
-    try {
-      foreach ($paths as $key => $path) {
+    foreach ($paths as $key => $path) {
+      try {
         $objectKey = sprintf($objectKeyTemplate, $key);
         $targetFile = implode(
               '/',
@@ -389,30 +389,30 @@ class BackupCommands extends BaseCommands {
               ['level' => 'info']
           );
       }
-    }
-    catch (\Throwable $e) {
-      $this->sentryClient->captureMessage(
-            'Files backup: ' . $e->getMessage(),
-            [],
-            ['level' => 'error']
-            );
-    }
-    finally {
-      $fileDeleted = unlink($targetFile);
-      
-      if($fileDeleted !== FALSE) {
-        var_dump($targetFile);
-        var_dump(" File Deleted");
-        $this->sentryClient->captureMessage("Successfully purged archieved temp file: " . $targetFile, [], [
-          'level' => 'info',
-        ]);
+      catch (\Throwable $e) {
+        $this->sentryClient->captureMessage(
+              'Files backup: ' . $e->getMessage(),
+              [],
+              ['level' => 'error']
+              );
       }
-      else {
-        var_dump($targetFile);
-        var_dump(" File not Deleted");
-        $this->sentryClient->captureMessage("Could not purge archieved temp file: " . $targetFile, [], [
-          'level' => 'error',
-        ]);
+      finally {
+        $fileDeleted = unlink($targetFile);
+        
+        if($fileDeleted !== FALSE) {
+          var_dump($targetFile);
+          var_dump(" File Deleted");
+          $this->sentryClient->captureMessage("Successfully purged archieved temp file: " . $targetFile, [], [
+            'level' => 'info',
+          ]);
+        }
+        else {
+          var_dump($targetFile);
+          var_dump(" File not Deleted");
+          $this->sentryClient->captureMessage("Could not purge archieved temp file: " . $targetFile, [], [
+            'level' => 'error',
+          ]);
+        }
       }
     }
   }


### PR DESCRIPTION
# Background
Currently if any exception occurs within the block where the backup files are created, the `unlink()` doesn't run properly. As a result dumped file to create backup is not cleared and takes up environment space. That sometimes results subsequent file dump effort into failure. 

# Solution
Make sure that created dump file will be deleted for sure if there is any exception or not.

# Technical Hint
- `unlink` is moved to `finally` block.
- Successful Purge is reported as `info`
- Any Failure in purge operation is reported as `error`