### PR TITLE
TSM-536: Maintenance: Change relative path to absolute for default.services.yml in site.settings.php

### DIFF
--- a/src/site.settings.php
+++ b/src/site.settings.php
@@ -13,7 +13,7 @@ if (!isset($settings)) {
   $settings = [];
 }
 
-$settings['container_yamls'][] = '../services/default.services.yml';
+$settings['container_yamls'][] = dirname(__DIR__) . '/services/default.services.yml';
 
 // Load service overrides.
 if (file_exists($app_root . '/' . $site_path . '/services.yml')) {


### PR DESCRIPTION
**Jira :** https://wearewondrous.atlassian.net/browse/TSM-536

### Background

>   When DRD gets site info from remote site, it also gets all directories to  the service yml file's. 
>   
>   In site.settings.php file psh-toolbelt uses the relative path(../services/default.services.yml) for default.services.yml to the module directory.
>   
>   Upon receiving the info from remote site DRD module tries to make relative path from the web root directory to those service yml files directories. 
>   
>   Since ../services/default/services.yml file is a relative path symfony file system throws error as it expects path to be absolute.

### Goal

- Make path to default.services.yml absolute in site.settings.php

### Acceptance

- Psh-toolbelt still works the same way.

### Test

- Tested if https://github.com/wearewondrous/psh-toolbelt/tree/TSM-536-Maintenance-Absolute-Path-For-default.services.yml is working on already opened https://github.com/wearewondrous/babygalerie-backend/pull/13 with this commit -> https://github.com/wearewondrous/babygalerie-backend/pull/13/commits/c382049f6d300145c47a79c8d143c0d185f70af0. ( Check Branch hash and to ensure we're using the right version of `psh-toolbelt`) 
- ran backup in pr env 
```
web@bfxbqq655tzes-pr-13-7gt46na--ksb_babygalerie:~$ vendor/bin/psh-toolbelt backup:branch --force
 [Exec] Running drush sql:dump | gzip > /app/tmp/babygalerie-bfxbqq655tzes--pr-13--2021-10-28T08:35:10+02:00--dump.sql.gz
 [Exec] Done in 1.147s
 [Exec] Running tar --exclude=.htaccess --exclude=js --exclude=css --exclude=styles --exclude=translations --exclude=languages --exclude=config -c web/sites/default/files/ | gzip > /app/tmp/babygalerie-bfxbqq655tzes--pr-13--2021-10-28T08:35:10+02:00--files-public.tar.gz
 [Exec] Done in 02:10
 [Exec] Running tar --exclude=.htaccess --exclude=js --exclude=css --exclude=styles --exclude=translations --exclude=languages --exclude=config -c private/ | gzip > /app/tmp/babygalerie-bfxbqq655tzes--pr-13--2021-10-28T08:35:10+02:00--files-private.tar.gz
 [Exec] Done in 0.006s
```

**PR running using this change :** https://www.pr-2-tcs3n7y-zt5dpqoo27gdc.eu-4.platformsh.site/
